### PR TITLE
Implement /deployments API endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    tags:
+      - 'v*.*.*'
     branches: ["main", "feature/**"]
     paths:
       - '**.go'
@@ -12,8 +14,9 @@ on:
       - '.github/workflows/ci.yml'
 
 jobs:
-  build:
+  release:
     runs-on: ubuntu-24.04
+    if: github.ref_type == 'tag'
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go
@@ -46,14 +49,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.K8S_CONTROLLER_TOKEN }}
       - name: Build Docker image
-        run: docker build -t ghcr.io/${{ steps.vars.outputs.owner_lc }}/app:${{ steps.vars.outputs.docker_tag }} .
+        run: docker build -t ghcr.io/${{ steps.vars.outputs.owner_lc }}/app:${{ steps.vars.outputs.app_version }} .
       - name: Trivy Scan
         uses: aquasecurity/trivy-action@0.28.0
         with:
           scan-type: 'image'
-          scan-ref: ghcr.io/${{ steps.vars.outputs.owner_lc }}/app:${{ steps.vars.outputs.docker_tag }}
+          scan-ref: ghcr.io/${{ steps.vars.outputs.owner_lc }}/app:${{ steps.vars.outputs.app_version }}
           format: table
           severity: HIGH,CRITICAL
           exit-code: 1
       - name: Publish Docker image
-        run: docker push ghcr.io/${{ steps.vars.outputs.owner_lc }}/app:${{ steps.vars.outputs.docker_tag }}
+        run: docker push ghcr.io/${{ steps.vars.outputs.owner_lc }}/app:${{ steps.vars.outputs.app_version }}

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ Authors: [Den Vasyliev](https://github.com/den-vasyliev) and [Alex Sudom](https:
 ## Prerequisites
 - Basic understanding of Kubernetes concepts
 
+## CI
+To setup GitHub Actions workflow follow steps described below:
+1. Generate PAT (personal access token). Select listed scopes: write:packages, repo. Copy secret.
+2. Go to `Settings` tab of your repository, choose `Security` section and select `Actions`. Create a `New repository secret` with name `K8S_CONTROLLER_TOKEN`, paste secret copied generated on step 1.
+
 ---
 
 ## Steps

--- a/docs/api-handler/README.md
+++ b/docs/api-handler/README.md
@@ -1,0 +1,35 @@
+## Implement /deployments API endpoint
+
+1. Adapt client-side caching mechanism to reduce API server calls to `api-server` Kubernetes cluster component.
+2. Add `/deployments` API endpoint to FastHTTP server
+3. Return JSON array of deployment names from the informer's local cache.
+
+### Informer's local cache
+
+- [cache](https://pkg.go.dev/k8s.io/client-go@v0.33.2/tools/cache#pkg-overview)
+
+    Package cache is a client-side caching mechanism. It is useful for reducing the number of server calls you'd otherwise need to make. Reflector watches a server and updates a Store. Two stores are provided; one that simply caches objects (for example, to allow a scheduler to list currently available nodes), and one that additionally acts as a FIFO queue (for example, to allow a scheduler to process incoming pods).
+
+- [GetStore](https://pkg.go.dev/k8s.io/client-go@v0.33.2/tools/cache#SharedInformer.GetStore) returns the informer's local cache as a Store
+
+    E.g.:
+    ```sh
+    deploymentInformer.GetStore().List()
+    ```
+
+### Usage:
+
+1. To compile controller, run:
+```sh
+make build
+```
+
+2. To start server, run
+```sh
+./k8s-controller --log-level trace --kubeconfig ~/.kube/config server --namespace <namespace> --labelSelectors labelName=labelValue
+```
+
+3. Call `/deployments` API endpoint to list deployment names for specified namespace and labelSelectors in step 2.
+```sh
+curl http://localhost:<port>/deployments
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "k8s-controller",
+  "version": "0.0.5",
+  "description": "Kubernetes controller written in Go",
+  "scripts": {
+    "publish": "git push --follow-tags"
+  }
+}

--- a/pkg/informer/informer.go
+++ b/pkg/informer/informer.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/rs/zerolog/log"
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/informers"
@@ -15,18 +16,26 @@ import (
 
 const resyncTime = 30 * time.Second
 
-func StartDeploymentInformer(ctx context.Context, clientset *kubernetes.Clientset, namespace string) {
+var deploymentInformer cache.SharedIndexInformer
+
+func StartDeploymentInformer(ctx context.Context, clientset *kubernetes.Clientset, namespace string, labelSelectors string) {
+	log.Info().Msgf("StartDeploymentInformer.namespace: %s", namespace)
+	log.Info().Msgf("StartDeploymentInformer.labelSelector: %s", labelSelectors)
+
 	factory := informers.NewSharedInformerFactoryWithOptions(
 		clientset,
 		resyncTime,
 		informers.WithNamespace(namespace),
 		informers.WithTweakListOptions(func(options *metav1.ListOptions) {
 			options.FieldSelector = fields.Everything().String()
+			if labelSelectors != "" {
+				options.LabelSelector = labelSelectors
+			}
 		}),
 	)
-	informer := factory.Apps().V1().Deployments().Informer()
+	deploymentInformer = factory.Apps().V1().Deployments().Informer()
 
-	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	deploymentInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			log.Info().Msgf("Deployment added: %s", getDeploymentName(obj))
 		},
@@ -48,6 +57,25 @@ func StartDeploymentInformer(ctx context.Context, clientset *kubernetes.Clientse
 	}
 	log.Info().Msg("Deployment informer cache synced. Watching for events...")
 	<-ctx.Done() // Block until context is cancelled
+}
+
+func GetDeploymentNames(namespace string) []string {
+	var names []string
+	log.Info().Msgf("GetDeploymentNames method: %s", namespace)
+	log.Info().Msgf("deploymentInformer: %s", deploymentInformer)
+	if deploymentInformer == nil {
+		log.Info().Msgf("deploymentInformer is nil")
+		return names
+	}
+	for _, obj := range deploymentInformer.GetStore().List() {
+		if d, ok := obj.(*appsv1.Deployment); ok {
+			// Filter by namespace
+			if d.Namespace == namespace {
+				names = append(names, d.Name)
+			}
+		}
+	}
+	return names
 }
 
 func getDeploymentName(obj any) string {


### PR DESCRIPTION
1. Adapt client-side caching mechanism to reduce API server calls to `api-server` Kubernetes cluster component.
2. Add `/deployments` API endpoint to FastHTTP server
3. Return JSON array of deployment names from the informer's local cache.