### PR TITLE
Adapt leader-election feature

### DIFF
--- a/docs/leader-election/README.md
+++ b/docs/leader-election/README.md
@@ -1,0 +1,28 @@
+## Leader Election and Metrics for Controller Manager
+
+- Added leader election support using a Lease resource (enabled by default, can be disabled with a flag).
+- Added a flag to set the metrics port for the controller manager.
+- Both features are configurable via CLI flags.
+
+#### New flags:
+
+- `--enable-leader-election` (default: true) — Enable/disable leader election for the controller manager.
+- `--metrics-port` (default: 8081) — Port for controller manager metrics endpoint.
+
+#### What it does:
+
+Ensures only one instance of the controller manager is active at a time (HA support).
+Exposes controller metrics on the specified port.
+
+
+#### Usage:
+
+1. To compile controller, run:
+```sh
+make build
+```
+
+2. To start server, run
+```sh
+./k8s-controller --log-level trace --kubeconfig ~/.kube/config server --enable-leader-election=false --metrics-port=9090
+```

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,9 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
 	github.com/valyala/fasthttp v1.62.0
+	go.etcd.io/etcd/client/v2 v2.305.21
 	k8s.io/api v0.33.2
+	k8s.io/apiextensions-apiserver v0.33.0
 	k8s.io/apimachinery v0.33.2
 	k8s.io/client-go v0.33.2
 	sigs.k8s.io/controller-runtime v0.21.0
@@ -18,6 +20,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
@@ -51,6 +54,8 @@ require (
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
+	go.etcd.io/etcd/api/v3 v3.5.21 // indirect
+	go.etcd.io/etcd/client/pkg/v3 v3.5.21 // indirect
 	golang.org/x/net v0.40.0 // indirect
 	golang.org/x/oauth2 v0.27.0 // indirect
 	golang.org/x/sync v0.14.0 // indirect
@@ -63,7 +68,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apiextensions-apiserver v0.33.0 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
+github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -133,6 +135,12 @@ github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZ
 github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+go.etcd.io/etcd/api/v3 v3.5.21 h1:A6O2/JDb3tvHhiIz3xf9nJ7REHvtEFJJ3veW3FbCnS8=
+go.etcd.io/etcd/api/v3 v3.5.21/go.mod h1:c3aH5wcvXv/9dqIw2Y810LDXJfhSYdHQ0vxmP3CCHVY=
+go.etcd.io/etcd/client/pkg/v3 v3.5.21 h1:lPBu71Y7osQmzlflM9OfeIV2JlmpBjqBNlLtcoBqUTc=
+go.etcd.io/etcd/client/pkg/v3 v3.5.21/go.mod h1:BgqT/IXPjK9NkeSDjbzwsHySX3yIle2+ndz28nVsjUs=
+go.etcd.io/etcd/client/v2 v2.305.21 h1:eLiFfexc2mE+pTLz9WwnoEsX5JTTpLCYVivKkmVXIRA=
+go.etcd.io/etcd/client/v2 v2.305.21/go.mod h1:OKkn4hlYNf43hpjEM3Ke3aRdUkhSl8xjKjSf8eCq2J8=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/pkg/testutil/envtest.go
+++ b/pkg/testutil/envtest.go
@@ -3,49 +3,115 @@ package testutil
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
+	"time"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
 	"github.com/stretchr/testify/require"
+	"go.etcd.io/etcd/client/v2"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/scale/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
+
+// StartTestManager sets up envtest, scheme, manager, and returns them with cleanup.
+func StartTestManager(t *testing.T) (mgr manager.Manager, k8sClient client.Client, restCfg *rest.Config, cleanup func()) {
+	t.Helper()
+	testScheme := runtime.NewScheme()
+
+	// Add the core Kubernetes schemes
+	require.NoError(t, scheme.AddToScheme(testScheme))
+	require.NoError(t, apiextensionsv1.AddToScheme(testScheme))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	env := &envtest.Environment{
+		ErrorIfCRDPathMissing:    true,
+		AttachControlPlaneOutput: false,
+	}
+	var startErr = make(chan error)
+	var cfg *rest.Config
+	var err error
+
+	go func() {
+		cfg, err = env.Start()
+		startErr <- err
+	}()
+
+	// Wait for environment to start with timeout
+	select {
+	case err := <-startErr:
+		require.NoError(t, err, "Failed to start test environment")
+	case <-ctx.Done():
+		t.Fatal("Timeout waiting for test environment to start")
+	}
+
+	require.NotNil(t, cfg)
+
+	mgr, err = manager.New(cfg, manager.Options{Scheme: testScheme, LeaderElection: false})
+	require.NoError(t, err)
+
+	ctx, cancel = context.WithCancel(context.Background())
+	go func() {
+		_ = mgr.Start(ctx)
+	}()
+
+	k8sClient = mgr.GetClient()
+
+	cleanup = func() {
+		cancel()
+		_ = env.Stop()
+	}
+	return mgr, k8sClient, cfg, cleanup
+}
 
 // SetupEnv starts envtest, creates a clientset, populates the cluster with sample Deployments, and returns env, clientset, and cleanup.
 func SetupEnv(t *testing.T) (*envtest.Environment, *kubernetes.Clientset, func()) {
 	t.Helper()
-	ctx := context.Background()
-	env := &envtest.Environment{}
+	testScheme := runtime.NewScheme()
 
-	cfg, err := env.Start()
+	// Add the core Kubernetes schemes
+	err := scheme.AddToScheme(testScheme)
 	require.NoError(t, err)
+
+	// Create a longer context timeout for environment startup
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Add CRD scheme
+	err = apiextensionsv1.AddToScheme(testScheme)
+	require.NoError(t, err)
+
+	env := &envtest.Environment{
+		ErrorIfCRDPathMissing:    true,
+		AttachControlPlaneOutput: false,
+	}
+
+	var startErr = make(chan error)
+	var cfg *rest.Config
+
+	go func() {
+		cfg, err = env.Start()
+		startErr <- err
+	}()
+
+	// Wait for environment to start with timeout
+	select {
+	case err := <-startErr:
+		require.NoError(t, err, "Failed to start test environment")
+	case <-ctx.Done():
+		t.Fatal("Timeout waiting for test environment to start")
+	}
+
 	require.NotNil(t, cfg)
-
-	// Write kubeconfig to /tmp/envtest.kubeconfig
-	kubeconfig := clientcmdapi.NewConfig()
-	kubeconfig.Clusters["envtest"] = &clientcmdapi.Cluster{
-		Server:                   cfg.Host,
-		CertificateAuthorityData: cfg.CAData,
-	}
-	kubeconfig.AuthInfos["envtest-user"] = &clientcmdapi.AuthInfo{
-		ClientCertificateData: cfg.CertData,
-		ClientKeyData:         cfg.KeyData,
-	}
-	kubeconfig.Contexts["envtest-context"] = &clientcmdapi.Context{
-		Cluster:  "envtest",
-		AuthInfo: "envtest-user",
-	}
-	kubeconfig.CurrentContext = "envtest-context"
-
-	kubeconfigBytes, err := clientcmd.Write(*kubeconfig)
-	require.NoError(t, err)
-	err = os.WriteFile("/tmp/envtest.kubeconfig", kubeconfigBytes, 0644)
-	require.NoError(t, err)
 
 	clientset, err := kubernetes.NewForConfig(cfg)
 	require.NoError(t, err)


### PR DESCRIPTION
- Added leader election support using a Lease resource (enabled by default, can be disabled with a flag).
- Added a flag to set the metrics port for the controller manager.
- Both features are configurable via CLI flags.